### PR TITLE
MRC-42 Currency formatting compatibility between Oracle JDK and jenkins Open JDK

### DIFF
--- a/app/utils/CurrencyUtils.scala
+++ b/app/utils/CurrencyUtils.scala
@@ -27,7 +27,10 @@ object CurrencyUtils {
   }
 
   def format(value: Number): String =
-    currencyFormatter.format(value).replace(".00", "")
+    currencyFormatter
+      .format(value)
+      .replace("GBP", "£")
+      .replace(".00", "")
 
   def roundUp(value: BigDecimal): Double =
     value.setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble


### PR DESCRIPTION
Locally, I am using Oracle JDK 1.8, while jenkins uses Open JDK 1.8

When formatting with a Currency formatter instance (UK) 100 is formatted as 

Local: £100
Jenkins: GBP100

Putting a fix in place