### PR TITLE
MRC-37 Fixing ahdoc failures due to string that contains only spaces

### DIFF
--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -95,7 +95,7 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
       .suchThat(_ != "false")
 
   def nonEmptyString: Gen[String] =
-    arbitrary[String] suchThat (_.nonEmpty)
+    arbitrary[String] suchThat (_.trim.nonEmpty)
 
   def stringsWithMaxLength(maxLength: Int): Gen[String] =
     for {


### PR DESCRIPTION
Failure as the input have a single space

`- return error when values are non-numbers *** FAILED ***
[info]     TestFailedException was thrown during property evaluation.
[info]       Message: List(FormError(associatedCompaniesCount,List(associatedCompaniesCount.error.required),List())) was not equal to List(FormError(associatedCompaniesCount,List(associatedCompaniesCount.error.nonNumeric),List()))
[info]       Location: (AssociatedCompaniesFormProviderSpec.scala:112)
[info]       Occurred when passed generated values (
[info]         nonNumbers = " "
[info]       )`