### PR TITLE
DLS-7038 | Update results page rendering to pick correct fyratio for adjusted upper limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,22 @@ The codebase uses the [scaffolding service](https://github.com/hmrc/hmrc-fronten
 
 ## Running in DEV mode
 
-To run the service you need the following installed: `Java 1.8`, `Mongo 4.0.25`, `sbt 1.7.1`
-
-To start the service locally, execute the following command
-
-```$ sbt -jvm-debug DEBUG_PORT run -Dapplication.router=testOnlyDoNotUseInAppConf.Routes ```
-@@ -13,6 +16,8 @@ To run locally using Service Manager
-
+To start the service locally using service manager, use `sm2 --start MARGINAL_RELIEF_CALCULATOR_FRONTEND`
+For a functioning frontend, it also needs following services to be running locally. They can be started via service manager using
 ```
-sm --start MARGINAL_RELIEF_CALCULATOR_BACKEND
+sm2 --start DATASTREAM
+sm2 --start MARGINAL_RELIEF_CALCULATOR_BACKEND
 ```
 
-```
-sm --start DATASTREAM
-```
+### From source code on your local machine
+Prior to starting the service from source, make sure the instance running in service manager is stopped. This can be done by running `sm2 --stop MARGINAL_RELIEF_CALCULATOR_FRONTEND`.
 
-```
-sm --start MARGINAL_RELIEF_CALCULATOR
-```
-This starts Marginal Relief Calculator (frontend) and all its dependencies
+To run the service locally from source code, you need the following installed: `Java 1.8`, `Mongo 4.0.25`, `sbt 1.7.1`
+
+```$ sbt run -Dapplication.router=testOnlyDoNotUseInAppConf.Routes ```
+
+To debug the locally running application from IDE, use `jvm-debug` sbt option and run
+```$ sbt run -jvm-debug 5005 -Dapplication.router=testOnlyDoNotUseInAppConf.Routes ```
 
 ## Starting the calculation journey (QA env)
 

--- a/app/views/helpers/FullResultsPageHelper.scala
+++ b/app/views/helpers/FullResultsPageHelper.scala
@@ -33,6 +33,7 @@ object FullResultsPageHelper extends ViewHelper {
   private val govukDetails = new GovukDetails()
 
   def nonTabCalculationResultsTable(
+    calculatorResult: CalculatorResult,
     taxDetailsWithAssociatedCompanies: Seq[(TaxDetails, Int)],
     taxableProfit: Int,
     distributions: Int,
@@ -71,6 +72,7 @@ object FullResultsPageHelper extends ViewHelper {
             )
           ),
           displayFullFinancialYearTable(
+            calculatorResult,
             marginal,
             associatedCompanies,
             taxableProfit,
@@ -115,6 +117,7 @@ object FullResultsPageHelper extends ViewHelper {
             styles = "margin-bottom: 4px;"
           )}
            |    ${displayFullFinancialYearTable(
+            calculatorResult,
             marginalRate,
             associatedCompanies,
             taxableProfit,
@@ -144,6 +147,7 @@ object FullResultsPageHelper extends ViewHelper {
           tabDisplay(taxDetailsWithAssociatedCompanies(Seq(y1, y2), associatedCompanies), daysInAccountingPeriod)
         case (y1: MarginalRate, y2: FlatRate) =>
           nonTabCalculationResultsTable(
+            calculatorResult,
             taxDetailsWithAssociatedCompanies(Seq(y1, y2), associatedCompanies),
             taxableProfit,
             distributions,
@@ -151,6 +155,7 @@ object FullResultsPageHelper extends ViewHelper {
           )
         case (y1: FlatRate, y2: MarginalRate) =>
           nonTabCalculationResultsTable(
+            calculatorResult,
             taxDetailsWithAssociatedCompanies(Seq(y1, y2), associatedCompanies),
             taxableProfit,
             distributions,
@@ -162,6 +167,7 @@ object FullResultsPageHelper extends ViewHelper {
 
     calculatorResult.fold(single =>
       nonTabCalculationResultsTable(
+        calculatorResult,
         taxDetailsWithAssociatedCompanies(Seq(single.details), associatedCompanies),
         taxableProfit,
         distributions,
@@ -212,6 +218,7 @@ object FullResultsPageHelper extends ViewHelper {
   private def isFiveStepMarginalRate(marginalRate: MarginalRate) = marginalRate.marginalRelief > 0
 
   private def displayFullFinancialYearTable(
+    calculatorResult: CalculatorResult,
     marginalRate: MarginalRate,
     associatedCompanies: Int,
     taxableProfit: Int,
@@ -230,7 +237,8 @@ object FullResultsPageHelper extends ViewHelper {
 
     val days = marginalRate.fyRatio.numerator.toInt
 
-    val daysInAccountingPeriod = marginalRate.fyRatio.denominator
+    val daysInAP = calculatorResult.totalDays
+    val daysInAPForAdjustedUL = marginalRate.fyRatio.denominator
 
     val upperThreshold = CurrencyUtils.format(yearConfig.upperThreshold)
 
@@ -284,7 +292,7 @@ object FullResultsPageHelper extends ViewHelper {
         TableRow(content =
           Text(
             s"${if (isProfitsAboveLowerThreshold) upperThresholdText
-              else lowerThresholdText} × ($daysString ÷ $daysInAccountingPeriod $daysMsg) ÷ $pointOneCompaniesCalcText"
+              else lowerThresholdText} × ($daysString ÷ $daysInAPForAdjustedUL $daysMsg) ÷ $pointOneCompaniesCalcText"
           )
         ),
         TableRow(content =
@@ -299,9 +307,7 @@ object FullResultsPageHelper extends ViewHelper {
       Seq(
         boldRow("2"),
         TableRow(content = Text(messages("fullResultsPage.financialYear.taxableProfit"))),
-        TableRow(content =
-          Text(s"${CurrencyUtils.format(taxableProfit)} × ($daysString ÷ $daysInAccountingPeriod $daysMsg)")
-        ),
+        TableRow(content = Text(s"${CurrencyUtils.format(taxableProfit)} × ($daysString ÷ $daysInAP $daysMsg)")),
         TableRow(content = Text(CurrencyUtils.format(marginalRate.adjustedProfit)))
       ),
       Seq(
@@ -310,7 +316,7 @@ object FullResultsPageHelper extends ViewHelper {
         TableRow(content =
           Text(
             s"(${CurrencyUtils.format(taxableProfit)} + ${CurrencyUtils
-                .format(distributions)}) × ($daysString ÷ $daysInAccountingPeriod $daysMsg)"
+                .format(distributions)}) × ($daysString ÷ $daysInAP $daysMsg)"
           )
         ),
         TableRow(content = Text(CurrencyUtils.format(taxableProfitIncludingDistributions)))

--- a/app/views/helpers/PDFFileTemplateHelper.scala
+++ b/app/views/helpers/PDFFileTemplateHelper.scala
@@ -43,6 +43,7 @@ object PDFFileTemplateHelper {
                 |          <h2 class="govuk-heading-l">${messages("fullResultsPage.howItsCalculated")}</h2>
                 |          <p class="govuk-body">${messages("fullResultsPage.marginalReliefForAccountingPeriod")}</p>
                 |          ${nonTabCalculationResultsTable(
+                 calculatorResult,
                  taxDetailsWithAssociatedCompanies(Seq(flatRate), associatedCompanies),
                  taxableProfit,
                  distributions,
@@ -61,6 +62,7 @@ object PDFFileTemplateHelper {
                 |          <h2 class="govuk-heading-l">${messages("fullResultsPage.howItsCalculated")}</h2>
                 |          <p class="govuk-body">${messages("fullResultsPage.marginalReliefForAccountingPeriod")}</p>
                 |          ${nonTabCalculationResultsTable(
+                 calculatorResult,
                  taxDetailsWithAssociatedCompanies(Seq(flatRate1, flatRate2), associatedCompanies),
                  taxableProfit,
                  distributions,
@@ -78,6 +80,7 @@ object PDFFileTemplateHelper {
                 |          <h2 class="govuk-heading-l">${messages("fullResultsPage.howItsCalculated")}</h2>
                 |          <p class="govuk-body">${messages("fullResultsPage.marginalReliefForAccountingPeriod")}</p>
                 |          ${nonTabCalculationResultsTable(
+                 calculatorResult,
                  taxDetailsWithAssociatedCompanies(Seq(marginalRate), associatedCompanies),
                  taxableProfit,
                  distributions,
@@ -96,6 +99,7 @@ object PDFFileTemplateHelper {
              |          <h2 class="govuk-heading-l">${messages("fullResultsPage.howItsCalculated")}</h2>
              |          <p class="govuk-body">${messages("fullResultsPage.marginalReliefForAccountingPeriod")}</p>
              |          ${nonTabCalculationResultsTable(
+              calculatorResult,
               taxDetailsWithAssociatedCompanies(Seq(flatRate, marginalRate), associatedCompanies),
               taxableProfit,
               distributions,
@@ -114,6 +118,7 @@ object PDFFileTemplateHelper {
                 |          <h2 class="govuk-heading-l">${messages("fullResultsPage.howItsCalculated")}</h2>
                 |          <p class="govuk-body">${messages("fullResultsPage.marginalReliefForAccountingPeriod")}</p>
                 |          ${nonTabCalculationResultsTable(
+                 calculatorResult,
                  taxDetailsWithAssociatedCompanies(Seq(marginalRate, flatRate), associatedCompanies),
                  taxableProfit,
                  distributions,
@@ -132,6 +137,7 @@ object PDFFileTemplateHelper {
              |          <h2 class="govuk-heading-l">${messages("fullResultsPage.howItsCalculated")}</h2>
              |          <p class="govuk-body">${messages("fullResultsPage.marginalReliefForAccountingPeriod")}</p>
              |          ${nonTabCalculationResultsTable(
+              calculatorResult,
               associatedCompanies match {
                 case Left(a)         => Seq(marginalRate1 -> a)
                 case Right((a1, a2)) => Seq(marginalRate1 -> a1)
@@ -146,6 +152,7 @@ object PDFFileTemplateHelper {
              |<div class="pdf-page">
              |          <div class="grid-row">
              |            ${nonTabCalculationResultsTable(
+              calculatorResult,
               associatedCompanies match {
                 case Left(a)         => Seq(marginalRate2 -> a)
                 case Right((a1, a2)) => Seq(marginalRate2 -> a2)

--- a/app/views/helpers/PDFViewHelper.scala
+++ b/app/views/helpers/PDFViewHelper.scala
@@ -56,6 +56,7 @@ object PDFViewHelper extends ViewHelper {
                 ${pdfCorporationTaxHtml("3", calculatorResult)}
              ${pdfDetailedCalculationHtml(
             nonTabCalculationResultsTable(
+              calculatorResult,
               taxDetailsWithAssociatedCompanies(Seq(flatRate), associatedCompanies),
               taxableProfit,
               distributions,
@@ -81,6 +82,7 @@ object PDFViewHelper extends ViewHelper {
                 ${pdfCorporationTaxHtml("3", calculatorResult)}
              ${pdfDetailedCalculationHtml(
             nonTabCalculationResultsTable(
+              calculatorResult,
               taxDetailsWithAssociatedCompanies(Seq(flatRate1, flatRate2), associatedCompanies),
               taxableProfit,
               distributions,
@@ -106,6 +108,7 @@ object PDFViewHelper extends ViewHelper {
                 ${pdfCorporationTaxHtml("3", calculatorResult)}
              ${pdfDetailedCalculationHtml(
             nonTabCalculationResultsTable(
+              calculatorResult,
               taxDetailsWithAssociatedCompanies(Seq(m), associatedCompanies),
               taxableProfit,
               distributions,
@@ -131,6 +134,7 @@ object PDFViewHelper extends ViewHelper {
                 ${pdfCorporationTaxHtml("3", calculatorResult)}
              ${pdfDetailedCalculationHtml(
             nonTabCalculationResultsTable(
+              calculatorResult,
               taxDetailsWithAssociatedCompanies(Seq(flatRate, m), associatedCompanies),
               taxableProfit,
               distributions,
@@ -157,6 +161,7 @@ object PDFViewHelper extends ViewHelper {
                 ${pdfCorporationTaxHtml("3", calculatorResult)}
                 ${pdfDetailedCalculationHtml(
             nonTabCalculationResultsTable(
+              calculatorResult,
               taxDetailsWithAssociatedCompanies(Seq(m, flatRate), associatedCompanies),
               taxableProfit,
               distributions,
@@ -182,6 +187,7 @@ object PDFViewHelper extends ViewHelper {
         ${pdfCorporationTaxHtml("4", calculatorResult)}
         ${pdfDetailedCalculationHtml(
             nonTabCalculationResultsTable(
+              calculatorResult,
               associatedCompanies match {
                 case Left(a)         => Seq(m1 -> a)
                 case Right((a1, a2)) => Seq(m1 -> a1)
@@ -196,6 +202,7 @@ object PDFViewHelper extends ViewHelper {
           )}
         ${pdfDetailedCalculationHtmlWithoutHeader(
             nonTabCalculationResultsTable(
+              calculatorResult,
               associatedCompanies match {
                 case Left(a)         => Seq(m2 -> a)
                 case Right((a1, a2)) => Seq(m2 -> a2)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.0")
 
-addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
+addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 
 addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
 

--- a/test/views/PDFFileTemplateSpec.scala
+++ b/test/views/PDFFileTemplateSpec.scala
@@ -60,7 +60,7 @@ class PDFFileTemplateSpec extends SpecBase {
           1,
           1,
           1,
-          FYRatio(1, 1)
+          FYRatio(1, 2)
         ),
         MarginalRate(
           accountingPeriodForm.accountingPeriodStartDate.getYear,
@@ -75,7 +75,7 @@ class PDFFileTemplateSpec extends SpecBase {
           1,
           1,
           1,
-          FYRatio(1, 1)
+          FYRatio(1, 2)
         ),
         1
       )
@@ -580,19 +580,19 @@ class PDFFileTemplateSpec extends SpecBase {
        |        <tr class="govuk-table__row">
        |         <th scope="row" class="govuk-table__header"><span class="sr-only">Step 1</span><span aria-hidden="true">1</span></th>
        |         <td class="govuk-table__cell">Adjusted lower limit</td>
-       |         <td class="govuk-table__cell">£50,000 lower limit × (1 day ÷ 1 days) ÷ (1 associated company + 1 original company)</td>
+       |         <td class="govuk-table__cell">£50,000 lower limit × (1 day ÷ 2 days) ÷ (1 associated company + 1 original company)</td>
        |         <td class="govuk-table__cell">£1</td>
        |        </tr>
        |        <tr class="govuk-table__row">
        |         <th scope="row" class="govuk-table__header"><span class="sr-only">Step 2</span><span aria-hidden="true">2</span></th>
        |         <td class="govuk-table__cell">Taxable profit</td>
-       |         <td class="govuk-table__cell">£1 × (1 day ÷ 1 days)</td>
+       |         <td class="govuk-table__cell">£1 × (1 day ÷ 2 days)</td>
        |         <td class="govuk-table__cell">£1</td>
        |        </tr>
        |        <tr class="govuk-table__row">
        |         <th scope="row" class="govuk-table__header"><span class="sr-only">Step 3</span><span aria-hidden="true">3</span></th>
        |         <td class="govuk-table__cell">Taxable profit including distributions</td>
-       |         <td class="govuk-table__cell">(£1 + £1) × (1 day ÷ 1 days)</td>
+       |         <td class="govuk-table__cell">(£1 + £1) × (1 day ÷ 2 days)</td>
        |         <td class="govuk-table__cell">£1</td>
        |        </tr>
        |        <tr class="govuk-table__row">
@@ -632,19 +632,19 @@ class PDFFileTemplateSpec extends SpecBase {
        |        <tr class="govuk-table__row">
        |         <th scope="row" class="govuk-table__header"><span class="sr-only">Step 1</span><span aria-hidden="true">1</span></th>
        |         <td class="govuk-table__cell">Adjusted lower limit</td>
-       |         <td class="govuk-table__cell">£50,000 lower limit × (1 day ÷ 1 days) ÷ (1 associated company + 1 original company)</td>
+       |         <td class="govuk-table__cell">£50,000 lower limit × (1 day ÷ 2 days) ÷ (1 associated company + 1 original company)</td>
        |         <td class="govuk-table__cell">£1</td>
        |        </tr>
        |        <tr class="govuk-table__row">
        |         <th scope="row" class="govuk-table__header"><span class="sr-only">Step 2</span><span aria-hidden="true">2</span></th>
        |         <td class="govuk-table__cell">Taxable profit</td>
-       |         <td class="govuk-table__cell">£1 × (1 day ÷ 1 days)</td>
+       |         <td class="govuk-table__cell">£1 × (1 day ÷ 2 days)</td>
        |         <td class="govuk-table__cell">£1</td>
        |        </tr>
        |        <tr class="govuk-table__row">
        |         <th scope="row" class="govuk-table__header"><span class="sr-only">Step 3</span><span aria-hidden="true">3</span></th>
        |         <td class="govuk-table__cell">Taxable profit including distributions</td>
-       |         <td class="govuk-table__cell">(£1 + £1) × (1 day ÷ 1 days)</td>
+       |         <td class="govuk-table__cell">(£1 + £1) × (1 day ÷ 2 days)</td>
        |         <td class="govuk-table__cell">£1</td>
        |        </tr>
        |        <tr class="govuk-table__row">

--- a/test/views/helpers/PDFFileTemplateHelperSpec.scala
+++ b/test/views/helpers/PDFFileTemplateHelperSpec.scala
@@ -374,13 +374,13 @@ class PDFFileTemplateHelperSpec extends AnyFreeSpec with Matchers {
           |               <tr class="govuk-table__row">
           |                  <th scope="row" class="govuk-table__header"  ><span class="sr-only">Step 2</span><span aria-hidden="true">2</span></th>
           |                  <td class="govuk-table__cell"  >fullResultsPage.financialYear.taxableProfit</td>
-          |                  <td class="govuk-table__cell"  >£1 × (1 fullResultsPage.day.singular ÷ 1 fullResultsPage.day.plural)</td>
+          |                  <td class="govuk-table__cell"  >£1 × (1 fullResultsPage.day.singular ÷ 3 fullResultsPage.day.plural)</td>
           |                  <td class="govuk-table__cell"  >£1</td>
           |               </tr>
           |               <tr class="govuk-table__row">
           |                  <th scope="row" class="govuk-table__header"  ><span class="sr-only">Step 3</span><span aria-hidden="true">3</span></th>
           |                  <td class="govuk-table__cell"  >fullResultsPage.financialYear.taxableProfitDistributions</td>
-          |                  <td class="govuk-table__cell"  >(£1 + £1) × (1 fullResultsPage.day.singular ÷ 1 fullResultsPage.day.plural)</td>
+          |                  <td class="govuk-table__cell"  >(£1 + £1) × (1 fullResultsPage.day.singular ÷ 3 fullResultsPage.day.plural)</td>
           |                  <td class="govuk-table__cell"  >£1</td>
           |               </tr>
           |               <tr class="govuk-table__row">
@@ -427,13 +427,13 @@ class PDFFileTemplateHelperSpec extends AnyFreeSpec with Matchers {
           |               <tr class="govuk-table__row">
           |                  <th scope="row" class="govuk-table__header"  ><span class="sr-only">Step 2</span><span aria-hidden="true">2</span></th>
           |                  <td class="govuk-table__cell"  >fullResultsPage.financialYear.taxableProfit</td>
-          |                  <td class="govuk-table__cell"  >£1 × (2 fullResultsPage.day.plural ÷ 2 fullResultsPage.day.plural)</td>
+          |                  <td class="govuk-table__cell"  >£1 × (2 fullResultsPage.day.plural ÷ 3 fullResultsPage.day.plural)</td>
           |                  <td class="govuk-table__cell"  >£2</td>
           |               </tr>
           |               <tr class="govuk-table__row">
           |                  <th scope="row" class="govuk-table__header"  ><span class="sr-only">Step 3</span><span aria-hidden="true">3</span></th>
           |                  <td class="govuk-table__cell"  >fullResultsPage.financialYear.taxableProfitDistributions</td>
-          |                  <td class="govuk-table__cell"  >(£1 + £1) × (2 fullResultsPage.day.plural ÷ 2 fullResultsPage.day.plural)</td>
+          |                  <td class="govuk-table__cell"  >(£1 + £1) × (2 fullResultsPage.day.plural ÷ 3 fullResultsPage.day.plural)</td>
           |                  <td class="govuk-table__cell"  >£2</td>
           |               </tr>
           |               <tr class="govuk-table__row">

--- a/test/views/helpers/PDFViewHelperSpec.scala
+++ b/test/views/helpers/PDFViewHelperSpec.scala
@@ -78,7 +78,7 @@ class PDFViewHelperSpec extends SpecBase {
             )}
                 ${pdfCorporationTaxHtml(pageCount, calculatorResult)}
                 ${pdfDetailedCalculationHtml(
-              nonTabCalculationResultsTable(Seq(flatRate -> 0), taxableProfit, distributions, config),
+              nonTabCalculationResultsTable(calculatorResult, Seq(flatRate -> 0), taxableProfit, distributions, config),
               calculatorResult,
               accountingPeriodForm,
               pageCount
@@ -112,6 +112,7 @@ class PDFViewHelperSpec extends SpecBase {
              ${pdfCorporationTaxHtml(pageCount, calculatorResult)}
              ${pdfDetailedCalculationHtml(
               nonTabCalculationResultsTable(
+                calculatorResult,
                 Seq(marginalRate -> 0),
                 taxableProfit,
                 distributions,
@@ -160,6 +161,7 @@ class PDFViewHelperSpec extends SpecBase {
                 ${pdfCorporationTaxHtml(pageCount, calculatorResult)}
                 ${pdfDetailedCalculationHtml(
               nonTabCalculationResultsTable(
+                calculatorResult,
                 Seq(flatRate1 -> 0, flatRate2 -> 0),
                 taxableProfit,
                 distributions,
@@ -205,6 +207,7 @@ class PDFViewHelperSpec extends SpecBase {
                 ${pdfCorporationTaxHtml(pageCount, calculatorResult)}
                 ${pdfDetailedCalculationHtml(
               nonTabCalculationResultsTable(
+                calculatorResult,
                 Seq(marginalRate -> 0, flatRate -> 0),
                 taxableProfit,
                 distributions,
@@ -250,6 +253,7 @@ class PDFViewHelperSpec extends SpecBase {
                 ${pdfCorporationTaxHtml(pageCount, calculatorResult)}
                 ${pdfDetailedCalculationHtml(
               nonTabCalculationResultsTable(
+                calculatorResult,
                 Seq(flatRate -> 0, marginalRate -> 0),
                 taxableProfit,
                 distributions,
@@ -295,6 +299,7 @@ class PDFViewHelperSpec extends SpecBase {
                 ${pdfCorporationTaxHtml(pageCount, calculatorResult)}
                 ${pdfDetailedCalculationHtml(
               nonTabCalculationResultsTable(
+                calculatorResult,
                 Seq(marginalRate1 -> 0),
                 taxableProfit,
                 distributions,
@@ -306,6 +311,7 @@ class PDFViewHelperSpec extends SpecBase {
             )}
         ${pdfDetailedCalculationHtmlWithoutHeader(
               nonTabCalculationResultsTable(
+                calculatorResult,
                 Seq(marginalRate2 -> 0),
                 taxableProfit,
                 distributions,


### PR DESCRIPTION
- Update results page rendering to use correct denominator for adjusted profit and upper limit
- Update `sbt-sassify` plugin for build to work properly with M1 macs
- Update README

![image](https://user-images.githubusercontent.com/102029646/224112613-8cab8dee-adcc-4a6e-ac05-ecaee91e91b1.png)
