### PR TITLE
DLS-7261 | Update distrubtions selection validation error message

### DIFF
--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -276,8 +276,7 @@ distribution.listItem4=bonysau yn dilyn ad-dalu cyfranddaliadau cyfalaf
 distribution.yes=Iawn
 distribution.no=Na
 distribution.checkYourAnswersLabel=A gawsoch unrhyw ddosbarthiadau?
-distribution.error.required=Dewiswch a gawsoch ddosbarthiadau ai peidio
-distribution.error.invalid=Dewiswch a gawsoch ddosbarthiadau ai peidio
+distribution.error.required=Dewiswch a oes angen cynnwys dosbarthiadau yn eich elw ai peidio
 distribution.change.hidden=Dosbarthu
 distribution.errorsummary=Mae problem wedi codi.
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -274,8 +274,7 @@ distribution.listItem4 = bonus issues following the repayment of share capital
 distribution.yes = Yes
 distribution.no = No
 distribution.checkYourAnswersLabel = Did your company receive any distributions?
-distribution.error.required = Select whether you received distributions or not.
-distribution.error.invalid = Select whether you received distributions or not.
+distribution.error.required = Select whether distributions need to be included in your profits or not
 distribution.change.hidden = Distribution
 distribution.errorsummary = There is a problem.
 


### PR DESCRIPTION
- Update `distribution.error.required ` message as per requirement
- Remove unused `distribution.error.invalid ` message key. As it's a boolean flag we never need it and is not used across the codebase. 