### PR TITLE
DLS-9818 - Remove maxlength attribute from DateInput fields

### DIFF
--- a/app/viewmodels/govuk/DateFluency.scala
+++ b/app/viewmodels/govuk/DateFluency.scala
@@ -53,7 +53,7 @@ trait DateFluency {
           value = field("day").value,
           label = Some(messages("date.day")),
           classes = s"govuk-input--width-2 ${errorClass("day")}".trim,
-          attributes = Map("maxlength" -> "2")
+          attributes = Map.empty
         ),
         InputItem(
           id = s"${field.id}.month",
@@ -61,7 +61,7 @@ trait DateFluency {
           value = field("month").value,
           label = Some(messages("date.month")),
           classes = s"govuk-input--width-2 ${errorClass("month")}".trim,
-          attributes = Map("maxlength" -> "2")
+          attributes = Map.empty
         ),
         InputItem(
           id = s"${field.id}.year",
@@ -69,7 +69,7 @@ trait DateFluency {
           value = field("year").value,
           label = Some(messages("date.year")),
           classes = s"govuk-input--width-4 ${errorClass("year")}".trim,
-          attributes = Map("maxlength" -> "4")
+          attributes = Map.empty
         )
       )
 

--- a/app/views/DistributionsIncludedView.scala.html
+++ b/app/views/DistributionsIncludedView.scala.html
@@ -38,7 +38,6 @@
         .withHint(HintViewModel(messages("distributionsIncluded.amountLabel")))
         .withPrefix(PrefixOrSuffix(content = Text("£")))
         .withCssClass("govuk-!-width-one-third")
-        .withAttribute("maxlength" -> "20")
     )
 }
 

--- a/app/views/TaxableProfitView.scala.html
+++ b/app/views/TaxableProfitView.scala.html
@@ -58,7 +58,6 @@
             .withPrefix(PrefixOrSuffix(content = Text("£")))
             .withCssClass("govuk-!-width-one-third")
             .withHint(HintViewModel(messages("taxableProfit.hint")))
-            .withAttribute("maxlength" -> "20")
         )
 
         <p class="govuk-body govuk-!-margin-bottom-9"></p>


### PR DESCRIPTION
Description
This PR removes the maxlength attributes from the day, month, and year input fields in DateViewModel, which is part of the DateFluency trait. These attributes were previously limiting the size of the input fields, meaning that a user could not enter more than a certain number of characters (2 for day and month, 4 for the year).